### PR TITLE
caffe2fluid: repair scale with rename variable

### DIFF
--- a/caffe2fluid/kaffe/paddle/network.py
+++ b/caffe2fluid/kaffe/paddle/network.py
@@ -528,14 +528,14 @@ class Network(object):
         if isinstance(input, list) and len(input) == 2:
             # for two tensor, here resets axis to 1. Maybe there is a bug for unkown case.
             axis = 1
-            output_shape = input[0].shape[axis:axis + num_axes]
+            bias_shape = input[0].shape[axis:axis + num_axes]
             scale_param = input[1]
             input = input[0]
         else:
-            output_shape = input.shape[axis:axis + num_axes]
+            bias_shape = input.shape[axis:axis + num_axes]
             param_attr = fluid.ParamAttr(name=prefix + 'scale')
             scale_param = fluid.layers.create_parameter(
-                shape=output_shape,
+                shape=bias_shape,
                 dtype=input.dtype,
                 name=name,
                 attr=param_attr,
@@ -548,7 +548,7 @@ class Network(object):
             axis=axis,
             name=self.get_unique_output_name(name, 'scale_mul'))
 
-        scale_shape = output_shape
+        scale_shape = bias_shape
         offset_attr = fluid.ParamAttr(name=prefix + 'offset')
         offset_param = fluid.layers.create_parameter(
             shape=scale_shape,


### PR DESCRIPTION
Under the remind of Long Wang, the variable of `output_shape` is renamed as `bias_shape`, wihch is more accurate.

