### PR TITLE
fix ParamAttr api in create_parameter, test=develop

### DIFF
--- a/x2paddle/core/fluid_code.py
+++ b/x2paddle/core/fluid_code.py
@@ -88,6 +88,8 @@ class Layer(object):
         for key, value in param_attr.items():
             if '\n' in str(value):
                 value = string(str(value).replace('\n', ','))
+            if str(key) == 'attr':
+                value = 'ParamAttr(' + str(value) + ')'
             layer_code = layer_code + key + "={}, ".format(value)
         layer_code = layer_code.strip(", ")
 

--- a/x2paddle/op_mapper/tf_op_mapper.py
+++ b/x2paddle/op_mapper/tf_op_mapper.py
@@ -85,7 +85,8 @@ class TFOpMapper(OpMapper):
 
         not_placeholder = list()
         for name in self.graph.input_nodes:
-            if self.graph.get_node(name).layer_type != "Placeholder" and self.graph.get_node(name).layer_type != "OneShotIterator":
+            if self.graph.get_node(name).layer_type != "Placeholder" 
+               and self.graph.get_node(name).layer_type != "OneShotIterator":
                 not_placeholder.append(name)
         for name in not_placeholder:
             idx = self.graph.input_nodes.index(name)


### PR DESCRIPTION
For Paddle version > 1.6, the following command will fail with error

```python
x2paddle_fc1_bias = fluid.layers.create_parameter(dtype='float32', shape=[128], name='x2paddle_fc1_bias', attr='x2paddle_fc1_bias', default_initializer=Constant(0.0))
```

with error log as following:

```log
Traceback (most recent call last):
  File "../../x2paddle/core/op_mapper.py", line 123, in save_inference_model
    inputs, outputs = model.x2paddle_net()
  File "/workspace/Github-qili93/X2Paddle/model_dir/mnist/model_with_code/model.py", line 7, in x2paddle_net
    x2paddle_fc1_bias = fluid.layers.create_parameter(dtype='float32', shape=[128], name='x2paddle_fc1_bias', attr='x2paddle_fc1_bias', default_initializer=Constant(0.0))
  File "/workspace/anaconda3/envs/pytorch/lib/python3.7/site-packages/paddle/fluid/layers/tensor.py", line 148, in create_parameter
    check_type(attr, 'attr', (type(None), ParamAttr), 'create_parameter')
  File "/workspace/anaconda3/envs/pytorch/lib/python3.7/site-packages/paddle/fluid/data_feeder.py", line 97, in check_type
    (input_name, op_name, expected_type, type(input), extra_message))
TypeError: The type of 'attr' in create_parameter must be (<class 'NoneType'>, <class 'paddle.fluid.param_attr.ParamAttr'>), but received <class 'str'>.
```

Need to change the generated code to 

```python
x2paddle_fc1_bias = fluid.layers.create_parameter(dtype='float32', shape=[128], name='x2paddle_fc1_bias', attr=ParamAttr('x2paddle_fc1_bias'), default_initializer=Constant(0.0))
```