### PR TITLE
Fix install error about code style.

### DIFF
--- a/x2paddle/op_mapper/tf_op_mapper.py
+++ b/x2paddle/op_mapper/tf_op_mapper.py
@@ -85,7 +85,7 @@ class TFOpMapper(OpMapper):
 
         not_placeholder = list()
         for name in self.graph.input_nodes:
-            if self.graph.get_node(name).layer_type != "Placeholder" 
+            if self.graph.get_node(name).layer_type != "Placeholder" \
                and self.graph.get_node(name).layer_type != "OneShotIterator":
                 not_placeholder.append(name)
         for name in not_placeholder:


### PR DESCRIPTION
    When use `python setup.py install`, it will report a error:

    ```
    File "/root/miniconda3/lib/python3.7/site-packages/x2paddle-0.7.2-py3.7.egg/x2paddle/op_mapper/tf_op_mapper.py", line 88
        if self.graph.get_node(name).layer_type != "Placeholder"
                                                                ^
    SyntaxError: invalid syntax
    ```

    This commit will resolve the problem.