### PR TITLE
fix bug: Reshape attr:shape may come from Gather by a scalar indices

### DIFF
--- a/x2paddle/op_mapper/onnx2paddle/opset9/opset.py
+++ b/x2paddle/op_mapper/onnx2paddle/opset9/opset.py
@@ -814,11 +814,13 @@ class OpSet9():
                 inputs=val_shape,
                 output=val_shape_cast,
                 param_attr={'dtype': string('int32')})
-            node.fluid_code.add_layer(
-                'reshape',
-                inputs=val_shape_cast,
-                output=val_shape_cast,
-                param_attr={'shape': val_shape.out_shapes[0]})
+            # shape may be [], come form Gather by scalar indices
+            if len(val_shape.out_shapes[0]) > 0:
+                node.fluid_code.add_layer(
+                    'reshape',
+                    inputs=val_shape_cast,
+                    output=val_shape_cast,
+                    param_attr={'shape': val_shape.out_shapes[0]})
             node.fluid_code.add_layer(
                 'reshape',
                 inputs={'x': val_x,
@@ -826,11 +828,13 @@ class OpSet9():
                 output=node,
                 param_attr=attr)
         else:
-            node.fluid_code.add_layer(
-                'reshape',
-                inputs=val_shape,
-                output=val_shape,
-                param_attr={'shape': val_shape.out_shapes[0]})
+            # shape may be [], come form Gather by scalar indices
+            if len(val_shape.out_shapes[0]) > 0:
+                node.fluid_code.add_layer(
+                    'reshape',
+                    inputs=val_shape,
+                    output=val_shape,
+                    param_attr={'shape': val_shape.out_shapes[0]})
             node.fluid_code.add_layer(
                 'reshape',
                 inputs={'x': val_x,


### PR DESCRIPTION
fix issue: #329 
fix this case: Gather a 1D tensor  by a scalar indices(0) will generate a scalar with shape [], which is a limited by shape inference in onnx.
![image](https://user-images.githubusercontent.com/12471701/89017062-55e0ea00-d34c-11ea-8357-03a0b7950f17.png)
