### PR TITLE
fix bug of nearest_interp

### DIFF
--- a/x2paddle/op_mapper/paddle2onnx/opset9/opset.py
+++ b/x2paddle/op_mapper/paddle2onnx/opset9/opset.py
@@ -749,11 +749,6 @@ class OpSet9(object):
                 mode='linear')
             node_list.extend([result_node])
             return node_list
-            #node = helper.make_node(
-            #    'Resize',
-            #    inputs=[op.input('X')[0], op.input('OutSize')[0]],
-            #    outputs=op.output('Out'),
-            #    mode='nearest')
         elif 'Scale' in input_names and len(op.input('Scale')) > 0:
             node = helper.make_node(
                 'Resize',


### PR DESCRIPTION
when nearest_interp use out_shapes to resize , not scale value. old code send out_shapes to ONNX:Resize(<=opset10), but ONNX:Resize(<=opset10) only support scale.