### PR TITLE
fix the tf bug

### DIFF
--- a/x2paddle/decoder/tf_decoder.py
+++ b/x2paddle/decoder/tf_decoder.py
@@ -172,7 +172,7 @@ class TFGraph(Graph):
         self._remove_isolated_node()
         self._optimize_dialiation_conv()
         self._remove_identity_node()
-#         self._remove_cast_node()
+        self._remove_cast_node()
         
 
     def get_node(self, node_name, copy=False):

--- a/x2paddle/decoder/tf_decoder.py
+++ b/x2paddle/decoder/tf_decoder.py
@@ -130,7 +130,7 @@ class TFGraph(Graph):
     def __init__(self, model, data_format="NHWC"):
         super(TFGraph, self).__init__(model)
         self.identity_map = dict()
-        self.multi_out_ops = ['Split', 'SplitV', 'IteratorV2']
+        self.multi_out_ops = ['Split', 'SplitV', 'IteratorV2', 'Unpack']
         self.tf_data_format = data_format
         self.graph_name = "TFModel"
 
@@ -172,7 +172,8 @@ class TFGraph(Graph):
         self._remove_isolated_node()
         self._optimize_dialiation_conv()
         self._remove_identity_node()
-        self._remove_cast_node()
+#         self._remove_cast_node()
+        
 
     def get_node(self, node_name, copy=False):
         items = node_name.strip().split(':')
@@ -192,6 +193,8 @@ class TFGraph(Graph):
     
     def get_input_node(self, node, idx=0, copy=False):
         input_node_name = node.layer.input[idx]
+        if idx > 0:
+            copy = True
         return self.get_node(input_node_name, copy)
 
     def remove_node(self, node_name):
@@ -402,7 +405,7 @@ class TFDecoder(object):
                 right_shape_been_input = False
                 while not right_shape_been_input:
                     try:
-                        shape = input(
+                        shape = raw_input(
                             "Shape of Input(e.g. None,224,224,3): ")
                     except:
                         shape = input("Shape of Input(e.g. None,224,224,3): ")

--- a/x2paddle/op_mapper/static/tf2paddle/tf_op_mapper.py
+++ b/x2paddle/op_mapper/static/tf2paddle/tf_op_mapper.py
@@ -75,15 +75,17 @@ class TFOpMapper(OpMapper):
         'Sub': 'fluid.layers.elementwise_sub',
         'Maximum': 'paddle.maximum',
         'Minimum': 'paddle.minimum',
+        'Mul': 'paddle.multiply',
+        'FloorDiv': 'paddle.floor_divide',
+        'FloorMod': 'paddle.floor_mod',
+        'LogicalAnd': 'logical_and',
+    }
+    bool_ops = {
         'LessEqual': 'paddle.less_equal',
         'GreaterEqual': 'paddle.greater_equal',
         'Greater': 'paddle.greater_than',
         'NotEqual': 'paddle.not_equal',
         'Equal': 'paddle.equal',
-        'Mul': 'paddle.multiply',
-        'FloorDiv': 'paddle.floor_divide',
-        'FloorMod': 'paddle.floor_mod',
-        'LogicalAnd': 'logical_and',
     }
 
     def __init__(self, decoder):
@@ -124,6 +126,8 @@ class TFOpMapper(OpMapper):
                 self.directly_map(node)
             elif op in self.elementwise_ops:
                 self.elementwise_map(node)
+            elif op in self.bool_ops:
+                self.bool_map(node)
             elif hasattr(self, op):
                 func = getattr(self, op)
                 func(node)
@@ -138,7 +142,8 @@ class TFOpMapper(OpMapper):
             op = node.layer_type
             if not hasattr(self, op) and \
                 op not in self.directly_map_ops and \
-                op not in self.elementwise_ops:
+                op not in self.elementwise_ops and \
+                op not in self.bool_ops:
                 unsupported_ops.add(op)
         if len(unsupported_ops) == 0:
             return True
@@ -167,9 +172,10 @@ class TFOpMapper(OpMapper):
             outputs=[node.name],
             **attr)
 
-    def elementwise_map(self, node):
-        assert node.layer_type in self.elementwise_ops
-        op_type = self.elementwise_ops[node.layer_type]
+    def elementwise_map(self, node, op_type=None):
+        if op_type is None:
+            assert node.layer_type in self.elementwise_ops
+            op_type = self.elementwise_ops[node.layer_type]
         x = self.graph.get_node(node.layer.input[0])
         y = self.graph.get_node(node.layer.input[1])
         x_shape = x.out_shapes[0]
@@ -180,6 +186,11 @@ class TFOpMapper(OpMapper):
                     "y": y.name},
             outputs=[node.name])
         self.paddle_graph.layers[layer_id].input_shapes = {"x": x_shape, "y": y_shape}
+        
+    def bool_map(self, node):
+        op_type = self.bool_ops[node.layer_type]
+        self.elementwise_map(node, op_type)
+        node.set_dtype("bool")
 
     def Placeholder(self, node):
         shape = node.out_shapes[0]

--- a/x2paddle/optimizer/elimination/dygraph/transpose_elimination.py
+++ b/x2paddle/optimizer/elimination/dygraph/transpose_elimination.py
@@ -178,13 +178,13 @@ class DygraphTransposeElimination(FuseBase):
                                 if _graph.layers[ipt].outputs[
                                         output_index] == _graph.layers[current_id].inputs[
                                             'x']:
-                                    if len(x_shape) <= 1:
+                                    if list(x_shape)==[1] or len(x_shape) < 1:
                                         elementwise_layers.append(current_id)
                                         continue
                                 elif _graph.layers[ipt].outputs[
                                         output_index] == _graph.layers[current_id].inputs[
                                             'y']:
-                                    if len(y_shape) <= 1:
+                                    if list(y_shape)==[1] or len(y_shape) < 1:
                                         elementwise_layers.append(current_id)
                                         continue
                                 else:
@@ -279,11 +279,6 @@ class DygraphTransposeElimination(FuseBase):
         for layer_id in list(set(optimized_concat_layers)):
             axis = graph.layers[layer_id].attrs.get('axis', 0)
             graph.layers[layer_id].attrs['axis'] = [0, 2, 3, 1][axis]
-        for layer_id in list(set(optimized_elementwise_layers)):
-            axis = graph.layers[layer_id].attrs.get('axis', -1)
-            graph.layers[layer_id].attrs['axis'] = [0, 2, 3, 1][axis]
-            if graph.layers[layer_id].kernel == "paddle.add":
-                graph.layers[layer_id].kernel = "fluid.layers.elementwise_add"
 
         current_transpose_num = self.get_transpose_num(graph)
         print(

--- a/x2paddle/optimizer/elimination/static/transpose_elimination.py
+++ b/x2paddle/optimizer/elimination/static/transpose_elimination.py
@@ -178,13 +178,13 @@ class StaticTransposeElimination(FuseBase):
                                 if _graph.layers[ipt].outputs[
                                         output_index] == _graph.layers[current_id].inputs[
                                             'x']:
-                                    if len(x_shape) <= 1:
+                                    if list(x_shape)==[1] or len(x_shape) < 1:
                                         elementwise_layers.append(current_id)
                                         continue
                                 elif _graph.layers[ipt].outputs[
                                         output_index] == _graph.layers[current_id].inputs[
                                             'y']:
-                                    if len(y_shape) <= 1:
+                                    if list(y_shape)==[1] or len(y_shape) < 1:
                                         elementwise_layers.append(current_id)
                                         continue
                                 else:
@@ -279,11 +279,6 @@ class StaticTransposeElimination(FuseBase):
         for layer_id in list(set(optimized_concat_layers)):
             axis = graph.layers[layer_id].attrs.get('axis', 0)
             graph.layers[layer_id].attrs['axis'] = [0, 2, 3, 1][axis]
-        for layer_id in list(set(optimized_elementwise_layers)):
-            axis = graph.layers[layer_id].attrs.get('axis', -1)
-            graph.layers[layer_id].attrs['axis'] = [0, 2, 3, 1][axis]
-            if graph.layers[layer_id].kernel == "paddle.add":
-                graph.layers[layer_id].kernel = "fluid.layers.elementwise_add"
 
         current_transpose_num = self.get_transpose_num(graph)
         print(


### PR DESCRIPTION
TensorFlow修复：
1. 修复Equal等bool输出类型的op，输出类型不正确问题。
2. 修复模型输入类型不正确问题。
3. 修复多输入混淆问题。
4. 修复elementwise类op有axis的问题。
transpose修改前后对比：
（第一行：前——release0.9上测试 ；第二行：后——develop上测试）（由于develop加了prelu的优化，所以有一些最初transpose的个数多一些）
EfficientNet
Transpose layers optimized, before: transpose_num=388, after: transpose_num=2
Transpose layers optimized, before: transpose_num=620, after: transpose_num=2
MTCNN-RNet
Transpose layers optimized, before: transpose_num=10, after: transpose_num=2
Transpose layers optimized, before: transpose_num=16, after: transpose_num=2
MobileNetV1
Transpose layers optimized, before: transpose_num=112, after: transpose_num=2
Transpose layers optimized, before: transpose_num=112, after: transpose_num=2
KerasBert
Transpose layers optimized, before: transpose_num=144, after: transpose_num=144
Transpose layers optimized, before: transpose_num=144, after: transpose_num=144
MTCNN-ONet
Transpose layers optimized, before: transpose_num=14, after: transpose_num=2
Transpose layers optimized, before: transpose_num=22, after: transpose_num=2
ResNetV2
Transpose layers optimized, before: transpose_num=426, after: transpose_num=2
Transpose layers optimized, before: transpose_num=426, after: transpose_num=2
UNet-GanUNet
Transpose layers optimized, before: transpose_num=32, after: transpose_num=32
Transpose layers optimized, before: transpose_num=32, after: transpose_num=32
YOLOv3
Transpose layers optimized, before: transpose_num=308, after: transpose_num=8
Transpose layers optimized, before: transpose_num=308, after: transpose_num=8
InceptionV4
Transpose layers optimized, before: transpose_num=634, after: transpose_num=2
Transpose layers optimized, before: transpose_num=634, after: transpose_num=2
MTCNN-PNet
Transpose layers optimized, before: transpose_num=14, after: transpose_num=4
Transpose layers optimized, before: transpose_num=20, after: transpose_num=4
MobileNetV2
Transpose layers optimized, before: transpose_num=142, after: transpose_num=2
Transpose layers optimized, before: transpose_num=142, after: transpose_num=2
ShuffleNet
Transpose layers optimized, before: transpose_num=239, after: transpose_num=52
Transpose layers optimized, before: transpose_num=239, after: transpose_num=52
UNet-UNet
Transpose layers optimized, before: transpose_num=64, after: transpose_num=26
Transpose layers optimized, before: transpose_num=64, after: transpose_num=26
AlBert
Transpose layers optimized, before: transpose_num=96, after: transpose_num=96
Transpose layers optimized, before: transpose_num=96, after: transpose_num=96
SqueezeNet
Transpose layers optimized, before: transpose_num=60, after: transpose_num=2
Transpose layers optimized, before: transpose_num=60, after: transpose_num=2
ResNetV1
Transpose layers optimized, before: transpose_num=434, after: transpose_num=2
Transpose layers optimized, before: transpose_num=434, after: transpose_num=2
MNASNetA1
Transpose layers optimized, before: transpose_num=228, after: transpose_num=2
Transpose layers optimized, before: transpose_num=228, after: transpose_num=2
VGG16
Transpose layers optimized, before: transpose_num=42, after: transpose_num=2
Transpose layers optimized, before: transpose_num=42, after: transpose_num=2
InceptionResNetV2
Transpose layers optimized, before: transpose_num=908, after: transpose_num=2
Transpose layers optimized, before: transpose_num=908, after: transpose_num=2
RetinaFace
Transpose layers optimized, before: transpose_num=210, after: transpose_num=28
Transpose layers optimized, before: transpose_num=210, after: transpose_num=28
ToyUNet-ToyUnet
Transpose layers optimized, before: transpose_num=30, after: transpose_num=26
Transpose layers optimized, before: transpose_num=30, after: transpose_num=26
ToyUNet-UNet
Transpose layers optimized, before: transpose_num=64, after: transpose_num=26
Transpose layers optimized, before: transpose_num=64, after: transpose_num=26


