### PR TITLE
fix the AveragePool

### DIFF
--- a/x2paddle/op_mapper/dygraph/onnx2paddle/opset9/opset.py
+++ b/x2paddle/op_mapper/dygraph/onnx2paddle/opset9/opset.py
@@ -1194,7 +1194,7 @@ class OpSet9():
         }
         self.paddle_graph.add_layer(
             paddle_op, 
-            inputs={'x': val_x.name}, 
+            inputs={'x': val_x if isinstance(val_x, str) else val_x.name}, 
             outputs=layer_outputs, 
             **layer_attrs)
 


### PR DESCRIPTION
修复 AveragePool 在Pad是返回为字符串时的bug。【ref：#499 】