### PR TITLE
[fix] add scope_name definition

### DIFF
--- a/x2paddle/op_mapper/pytorch2paddle/aten.py
+++ b/x2paddle/op_mapper/pytorch2paddle/aten.py
@@ -1241,7 +1241,6 @@ def aten_contiguous(mapper, graph, node):
     output_name = mapper._get_outputs_name(node)[0]
     layer_outputs = [output_name]
     layer_inputs = {}
-    layer_attrs = {}
     inputs_name, inputs_node = mapper._get_inputs_name(node)
     # 获取当前节点输出的list
     current_outputs = [output_name]
@@ -1560,7 +1559,6 @@ def aten_detach(mapper, graph, node):
     output_name = mapper._get_outputs_name(node)[0]
     layer_outputs = [output_name]
     layer_inputs = {}
-    layer_attrs = {}
     inputs_name, inputs_node = mapper._get_inputs_name(node)
     # 获取当前节点输出的list
     current_outputs = [output_name]
@@ -2727,7 +2725,6 @@ def aten_index_select(mapper, graph, node):
         mapper._check_input(graph, inputs_node[1], inputs_name[1],
                             current_outputs, scope_name)
         layer_inputs["axis"] = inputs_name[1]
-        current_inputs.append(inputs_name[1])
     # 处理输入2，即%371
     mapper._check_input(graph, inputs_node[2], inputs_name[2], current_outputs,
                         scope_name)
@@ -3309,7 +3306,6 @@ def aten_masked_fill_(mapper, graph, node):
     scope_name = mapper.normalize_scope_name(node)
     output_name = mapper._get_outputs_name(node)[0]
     layer_outputs = [output_name]
-    layer_inputs = {}
     inputs_name, inputs_node = mapper._get_inputs_name(node)
     # 获取当前节点输入的list
     current_inputs = []
@@ -3419,7 +3415,6 @@ def aten_masked_fill(mapper, graph, node):
     scope_name = mapper.normalize_scope_name(node)
     output_name = mapper._get_outputs_name(node)[0]
     layer_outputs = [output_name]
-    layer_inputs = {}
     inputs_name, inputs_node = mapper._get_inputs_name(node)
     # 获取当前节点输入的list
     current_inputs = []
@@ -4554,7 +4549,6 @@ def aten_rsub(mapper, graph, node):
     output_name = mapper._get_outputs_name(node)[0]
     layer_outputs = [output_name]
     layer_inputs = {}
-    layer_attrs = {}
     inputs_name, inputs_node = mapper._get_inputs_name(node)
     # 获取当前节点输出的list
     current_outputs = [output_name]
@@ -4594,7 +4588,6 @@ def aten_ScalarImplicit(mapper, graph, node):
     output_name = mapper._get_outputs_name(node)[0]
     layer_outputs = [output_name]
     layer_inputs = {}
-    layer_attrs = {}
     inputs_name, inputs_node = mapper._get_inputs_name(node)
     # 获取当前节点输出的list
     current_outputs = [output_name]
@@ -5377,7 +5370,6 @@ def aten_transpose(mapper, graph, node):
     output_name = mapper._get_outputs_name(node)[0]
     layer_outputs = [output_name]
     layer_inputs = {}
-    layer_attrs = {}
     inputs_name, inputs_node = mapper._get_inputs_name(node)
     # 获取当前节点输出的list
     current_outputs = [output_name]

--- a/x2paddle/op_mapper/pytorch2paddle/aten.py
+++ b/x2paddle/op_mapper/pytorch2paddle/aten.py
@@ -2735,7 +2735,7 @@ def aten_index_select(mapper, graph, node):
     graph.add_layer(
         "prim.index_select",
         inputs=layer_inputs,
-        outputs=current_outputs,
+        outputs=layer_outputs,
         scope_name=scope_name,
         **layer_attrs)
     return current_inputs, current_outputs
@@ -4645,7 +4645,7 @@ def aten_select(mapper, graph, node):
     graph.add_layer(
         "prim.select",
         inputs=layer_inputs,
-        outputs=current_outputs,
+        outputs=layer_outputs,
         scope_name=scope_name,
         **layer_attrs)
     return current_inputs, current_outputs

--- a/x2paddle/op_mapper/pytorch2paddle/aten.py
+++ b/x2paddle/op_mapper/pytorch2paddle/aten.py
@@ -1645,6 +1645,7 @@ def aten_div_(mapper, graph, node):
         %bx_bw.3 (-): 被除数。
         %2678 (int): 除数。
     """
+    scope_name = mapper.normalize_scope_name(node)
     output_name = mapper._get_outputs_name(node)[0]
     layer_outputs = [output_name]
     layer_inputs = {}


### PR DESCRIPTION
1. Add `scope_name` definition into `x2paddle/op_mapper/pytorch2paddle/aten.py`. Missing `scope_name` will cause throwing `NameError: name 'scope_name' is not defined` when convert pytorch model file into paddlepaddle model file.
2. remove some unused variables in `x2paddle/op_mapper/pytorch2paddle/aten.py`
3. The `outputs` parameter of function `graph.add_layer` should be `layer_outputs` not `current_outputs`.

> 下面的文字请保留在PR说明的最后面，并在提完PR后，根据实际情况勾选确认以下情况  

Please check the follow step before merging this pull request

- [x] Python code style verification
- [x] Review all the code diff by yourself
- [x] All models(TensorFLow/Caffe/ONNX/PyTorch) testing passed
- [x] Details about your pull request, releated issues

If this PR add new model support, please update `model_zoo.md` and add model to out test model zoos(@wjj19950828)
- [ ] New Model Supported
- [x] No New Model Supported
