### PR TITLE
Fixed ONNX Pad bug and Add some op

### DIFF
--- a/x2paddle/op_mapper/onnx2paddle/opset9/opset.py
+++ b/x2paddle/op_mapper/onnx2paddle/opset9/opset.py
@@ -403,7 +403,7 @@ class OpSet9():
                 self.paddle_graph.add_layer(
                     "paddle.slice",
                     inputs={"input": val_scales.name},
-                    outputs=[val_scales.name+'_slice'],
+                    outputs=[val_scales.name + '_slice'],
                     axes=[0],
                     starts=[2],
                     ends=[4])
@@ -597,7 +597,7 @@ class OpSet9():
                         pads)  # NCHW
                 if assume_pad:
                     paddle_op = 'paddle.nn.Pad2D'
-                    # x1_begin,x2_begin,x3_begin,x4_begin,x1_end,x2_end,x3_end,x4_end -> x1_begin,x1_end,x2_begin,x2_end,x3_begin,x3_end,x4_begin,x4_end
+                    # x1_begin,x2_begin,x3_begin,x4_begin,x1_end,x2_end,x3_end,x4_end->x1_begin,x1_end,x2_begin,x2_end,x3_begin,x3_end,x4_begin,x4_end
                     paddings = np.array(pads).reshape(
                         (2, -1)).transpose().astype("int32")
                     paddings = paddings.flatten().tolist()
@@ -1318,9 +1318,7 @@ class OpSet9():
                 outputs=[node.name],
                 **layer_attrs)
             self.paddle_graph.add_layer(
-                'paddle.square',
-                inputs={"x": node.name},
-                outputs=[node.name])
+                'paddle.square', inputs={"x": node.name}, outputs=[node.name])
         else:
             axes = self.graph.get_input_node(node, idx=1, copy=True)
             axes_value = _const_weight_or_none(axes)
@@ -1338,9 +1336,7 @@ class OpSet9():
                 outputs=[node.name],
                 **layer_attrs)
             self.paddle_graph.add_layer(
-                'paddle.square',
-                inputs={"x": node.name},
-                outputs=[node.name])
+                'paddle.square', inputs={"x": node.name}, outputs=[node.name])
 
     @print_mapping_info
     def Max(self, node):

--- a/x2paddle/op_mapper/onnx2paddle/opset9/opset.py
+++ b/x2paddle/op_mapper/onnx2paddle/opset9/opset.py
@@ -600,8 +600,17 @@ class OpSet9():
                     # x1_begin,x2_begin,x3_begin,x4_begin,x1_end,x2_end,x3_end,x4_end->x1_begin,x1_end,x2_begin,x2_end,x3_begin,x3_end,x4_begin,x4_end
                     paddings = np.array(pads).reshape(
                         (2, -1)).transpose().astype("int32")
-                    paddings = paddings.flatten().tolist()
-                    layer_attrs['padding'] = paddings
+                    if mode == 'constant':
+                        paddings = paddings.flatten().tolist()
+                        layer_attrs['padding'] = paddings
+                    else:
+                        paddings = np.flip(paddings, axis=0).flatten().tolist()
+                        if sum(paddings[:4]) == 0:
+                            paddings = paddings[4:]
+                            layer_attrs['padding'] = paddings
+                        else:
+                            layer_attrs["pad"] = paddings
+                            paddle_op = "custom_layer:PadAllDim4WithOneInput"
             else:
                 pad_data = node.get_attr('pads')
                 pad_data1 = pad_data[0::2]


### PR DESCRIPTION
# Create A Good Pull Request

> 下面的文字请保留在PR说明的最后面，并在提完PR后，根据实际情况勾选确认以下情况  

Please check the follow step before merging this pull request

- [x] Python code style verification
- [x] Review all the code diff by yourself
- [x] All models(TensorFLow/Caffe/ONNX/PyTorch) testing passed
- [x] Details about your pull request, releated issues

If this PR add new model support, please update `model_zoo.md` and add model to out test model zoos(@wjj19950828)
- [x] New Model Supported
- [ ] No New Model Supported

## Do follow contributes
1、Fixed Pad op bug
2、Add LessOrEqual、ReduceSumSquare ops

## Describe
1、Pad 新增逻辑，如果 mode 为 'constant'，并且 pad 的长度为 x 维度的2倍时，则会根据 pad 和 value 对 x 从前面的维度向后依次补齐；参考官网：https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/functional/pad_cn.html#pad
2、关于_interpolate修改output name，是因为遇到情况：后面的op要用到slice之前的tensor，但目前逻辑为slice前后tensor的name一样，导致后面的OP用到的为slice之后的tensor，导致出错