### PR TITLE
docs目录中的有关save_image的代码组合的错误

### DIFF
--- a/docs/pytorch_project_convertor/API_docs/vision/torchvision.utils.save_image.md
+++ b/docs/pytorch_project_convertor/API_docs/vision/torchvision.utils.save_image.md
@@ -46,11 +46,10 @@ def make_grid(tensor: Union[paddle.Tensor, List[paddle.Tensor]],
     if tensor.dim() == 2:  # single image H x W
         tensor = tensor.unsqueeze(0)
     if tensor.dim() == 3:  # single image
-        if tensor.size(0) == 1:  # if single-channel, convert to 3-channel
+        if tensor.shape[0] == 1:  # if single-channel, convert to 3-channel
             tensor = paddle.concat((tensor, tensor, tensor), 0)
         tensor = tensor.unsqueeze(0)
-
-    if tensor.dim() == 4 and tensor.size(1) == 1:  # single-channel images
+    if tensor.dim() == 4 and tensor.shape[1] == 1:  # single-channel images
         tensor = paddle.concat((tensor, tensor, tensor), 1)
 
     if normalize is True:
@@ -75,11 +74,11 @@ def make_grid(tensor: Union[paddle.Tensor, List[paddle.Tensor]],
         else:
             norm_range(tensor, value_range)
 
-    if tensor.size(0) == 1:
+    if tensor.shape[0] == 1:
         return tensor.squeeze(0)
 
     # make the mini-batch of images into a grid
-    nmaps = tensor.size(0)
+    nmaps = tensor.shape[0]
     xmaps = min(nrow, nmaps)
     ymaps = int(math.ceil(float(nmaps) / xmaps))
     height, width = int(tensor.shape[2] + padding), int(tensor.shape[3] +


### PR DESCRIPTION
# Create A Good Pull Request
在torchvision.utils.save_image.md文件中的make_grid函数中：
原来使用size返回的是张量的单元数量，是一个shape为[1]的int64的张量，不是图像的通道数。因此这个代码无法正确运行。
应该将里面的size(0)改为shape[0]，size(1)改为shape[1]。

> 下面的文字请保留在PR说明的最后面，并在提完PR后，根据实际情况勾选确认以下情况  

Please check the follow step before merging this pull request

- [x ] Python code style verification
- [x ] Review all the code diff by yourself
- [ ] All models(TensorFLow/Caffe/ONNX/PyTorch) testing passed
- [ ] Details about your pull request, releated issues

If this PR add new model support, please update `model_zoo.md` and add model to out test model zoos(@wjj19950828)
- [ ] New Model Supported
- [x] No New Model Supported
