### PR TITLE
add Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8-gcc82
+
+RUN wget https://paddle-qa.bj.bcebos.com/PaddleX2paddle/torch-1.7.0-cp37-cp37m-linux_x86_64.whl --no-proxy && \
+    wget https://paddle-qa.bj.bcebos.com/PaddleX2paddle/torchvision-0.8.1-cp37-cp37m-linux_x86_64.whl --no-proxy && \
+    wget https://paddle-wheel.bj.bcebos.com/2.4.2/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.2.post112-cp37-cp37m-linux_x86_64.whl --no-proxy
+
+RUN python --version && unlink /usr/bin/python && ln -s /usr/bin/python3.7 /usr/bin/python
+
+ENV HTTP_PROXY <HTTP_PROXY>
+ENV HTTPS_PROXY <HTTPS_PROXY>
+RUN export http_proxy=$HTTP_PROXY
+RUN export https_proxy=$HTTPS_PROXY
+
+RUN python -m pip install --upgrade pip && \
+    python -m pip install wget timm transformers==3.1.0 ./*.whl pandas nose pytest opencv-python==4.6.0.66 allure-pytest && \
+    python -m pip install pynvml psutil GPUtil sympy treelib tensorflow==1.14.0 onnx==1.8.0 easyocr==1.2.1 && \
+    python -m pip install torchmetrics==0.10.2 pytorch_lightning==1.5.3 kornia==0.5.11

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,5 @@
+#生成镜像
+docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy -t paddlepaddle/x2paddle:latest-dev-cuda11.2-cudnn8-gcc82 .
+
+#进入镜像
+nvidia-docker run -it --cpu-shares=20000 --name=user-x2paddle --rm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi -v $(pwd):/workspace paddlepaddle/x2paddle:latest-dev-cuda11.2-cudnn8-gcc82 /bin/bash

--- a/test_benchmark/test_ci.sh
+++ b/test_benchmark/test_ci.sh
@@ -1,39 +1,4 @@
-#docker 命令参考
-#nvidia-docker run -it --cpu-shares=20000 --name=x2paddle --rm -v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi -v $(pwd):/workspace paddlepaddle/paddle:latest-dev-cuda11.2-cudnn8-gcc82 /bin/bash
-
-#下载最新dev paddle/torch/torchvison
-wget -nc https://paddle-qa.bj.bcebos.com/PaddleX2paddle/torch-1.7.0-cp37-cp37m-linux_x86_64.whl 
-wget -nc https://paddle-qa.bj.bcebos.com/PaddleX2paddle/torchvision-0.8.1-cp37-cp37m-linux_x86_64.whl 
-wget -nc https://paddle-wheel.bj.bcebos.com/2.4.2/linux/linux-gpu-cuda11.2-cudnn8-mkl-gcc8.2-avx/paddlepaddle_gpu-2.4.2.post112-cp37-cp37m-linux_x86_64.whl
-
-#设定python版本
-python --version
-#which python
-ls /usr/bin
-unlink /usr/bin/python
-ln -s /usr/bin/python3.7 /usr/bin/python
-python --version
-
-#python -m pip config set global.index-url https://mirror.baidu.com/pypi/simple;
-python -m pip install --upgrade pip;
-python -m pip install wget;
-python -m pip install timm;
-python -m pip install transformers==3.1.0;
-python -m pip install ./*.whl;
-python -m pip install pandas;
-python -m pip install nose;
-python -m pip install pytest;
-python -m pip install opencv-python==4.6.0.66;
-python -m pip install allure-pytest;
-python -m pip install pynvml psutil GPUtil;
-python -m pip install sympy;
-python -m pip install treelib;
-python -m pip install tensorflow==1.14.0;
-python -m pip install onnx==1.8.0;
-python -m pip install easyocr==1.2.1;
-python -m pip install torchmetrics==0.10.2;
-python -m pip install pytorch_lightning==1.5.3;
-python -m pip install kornia==0.5.11;
+#docker 命令参考: docker/run.sh
 
 export LD_LIBRARY_PATH=/usr/lib64:${LD_LIBRARY_PATH};
 # build x2paddle


### PR DESCRIPTION
1. 新增适配 paddle=2.4.2 的 x2paddle 镜像，镜像已上传到 https://hub.docker.com/r/paddlepaddle/x2paddle 。后续 CI 直接拉取该镜像，减少安装各种依赖的时间约 35 分钟。
2. 简化 test_ci.sh 。