### PR TITLE
Update gather.py

### DIFF
--- a/x2paddle/op_mapper/pytorch2paddle/pytorch_custom_layer/gather.py
+++ b/x2paddle/op_mapper/pytorch2paddle/pytorch_custom_layer/gather.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import paddle
-from x2paddle.core.util import *
 
 
 class Gather(object):
@@ -24,35 +23,6 @@ class Gather(object):
     def __call__(self, x, index):
         if self.dim < 0:
             self.dim += len(x.shape)
-        x_range = list(range(len(x.shape)))
-        x_range[0] = self.dim
-        x_range[self.dim] = 0
-        x_swaped = paddle.transpose(x, perm=x_range)
-        index_range = list(range(len(index.shape)))
-        index_range[0] = self.dim
-        index_range[self.dim] = 0
-        index_swaped = paddle.transpose(index, perm=index_range)
-        dtype = index.dtype
-
-        x_shape = paddle.shape(x_swaped)
-        index_shape = paddle.shape(index_swaped)
-
-        prod = paddle.cast(paddle.prod(x_shape), dtype=dtype) / x_shape[0]
-
-        x_swaped_flattend = paddle.flatten(x_swaped)
-        index_swaped_flattend = paddle.flatten(index_swaped)
-        index_swaped_flattend *= prod
-
-        bias = paddle.arange(start=0, end=prod, dtype=dtype)
-        bias = paddle.reshape(bias, x_shape[1:])
-        bias = paddle.crop(bias, index_shape[1:])
-        bias = paddle.flatten(bias)
-        bias = paddle.tile(bias, [index_shape[0]])
-        index_swaped_flattend += bias
-
-        gathered = paddle.index_select(x_swaped_flattend, index_swaped_flattend)
-        gathered = paddle.reshape(gathered, index_swaped.shape)
-
-        out = paddle.transpose(gathered, perm=x_range)
+        out = paddle.take_along_axis(x, index, self.dim)
 
         return out


### PR DESCRIPTION
在导出doclayoutyolo为paddle模型过程中，gather算子报错，查询发现paddle3.1 已经具有等价API paddle.take_along_axis 支持 torch.gather，最小复现case如下代码：
```
#!/usr/bin/env python
"""
-*- coding: utf-8 -*-
@Author  : guoquanhao
@E-mail  : cybergodhao@gmail.com
@Time    : 2025/7/30 下午11:12
@File    : 1.py
@Software: PyCharm
@Desc    :
"""

from x2paddle.convert import pytorch2paddle

import torch
import torch.nn as nn


class MaxValueModel(nn.Module):
    def __init__(self):
        super(MaxValueModel, self).__init__()

    def forward(self, x):
        output = x.gather(dim=1, index=torch.ones(1, 300, 4).long())

        return output


torch_module = MaxValueModel()
pytorch2paddle(module=torch_module,
               save_dir="./pd_model",
               jit_type="trace",
               input_examples=[torch.randn(1, 8400, 4)])
```
使用旧版会报错如下，修改后即可正确
```
TypeError: (InvalidType) Type promotion only support calculations between floating-point numbers and between complex and real numbers. But got different data type x: float32, y: int64. (at /paddle/paddle/phi/common/type_promotion.h:230)
```


