### PR TITLE
[Fix] Refactor ONNX type mapping to use tensor_dtype_to_np_dtype

### DIFF
--- a/x2paddle/decoder/onnx_decoder.py
+++ b/x2paddle/decoder/onnx_decoder.py
@@ -19,7 +19,7 @@ from onnx.checker import check_model
 from onnx import helper, shape_inference
 from onnx.helper import get_attribute_value, make_attribute
 from onnx.shape_inference import infer_shapes
-from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE
+from onnx.helper import tensor_dtype_to_np_dtype
 from onnx.numpy_helper import to_array
 from onnx import AttributeProto, TensorProto, GraphProto
 from collections import OrderedDict as Dict
@@ -87,7 +87,7 @@ class ONNXGraphNode(GraphNode):
         get_attribute_value enhanced
         """
         if attr.type == onnx.AttributeProto.TENSOR:
-            dtype = np.dtype(TENSOR_TYPE_TO_NP_TYPE[attr.t.data_type])
+            dtype = np.dtype(tensor_dtype_to_np_dtype(attr.t.data_type))
             data = attr.t.raw_data
             value = np.frombuffer(data,
                                   dtype=dtype,
@@ -169,10 +169,10 @@ class ONNXGraphDataNode(GraphNode):
     def dtype(self):
         if isinstance(self.layer, ValueInfoProto):
             dtype = self.layer.type.tensor_type.elem_type
-            return TENSOR_TYPE_TO_NP_TYPE[dtype]
+            return tensor_dtype_to_np_dtype(dtype)
         else:
             dtype = self.layer.data_type
-            return TENSOR_TYPE_TO_NP_TYPE[dtype]
+            return tensor_dtype_to_np_dtype(dtype)
 
 
 class ONNXGraph(Graph):
@@ -371,7 +371,7 @@ class ONNXGraph(Graph):
         for item in self.graph.value_info:
             self.value_infos[item.name] = {
                 'dtype':
-                TENSOR_TYPE_TO_NP_TYPE[item.type.tensor_type.elem_type],
+                tensor_dtype_to_np_dtype(item.type.tensor_type.elem_type),
                 'shape':
                 [dim.dim_value for dim in item.type.tensor_type.shape.dim],
                 'external': False
@@ -533,7 +533,7 @@ class ONNXDecoder(object):
             elif not keep_input_only and name in output_refs:
                 ret_initializers.add().CopyFrom(initializer)
             else:
-                dtype = TENSOR_TYPE_TO_NP_TYPE[initializer.data_type]
+                dtype = tensor_dtype_to_np_dtype(initializer.data_type)
 
         # strip inputs
         ret.graph.ClearField('input')

--- a/x2paddle/decoder/onnx_decoder.py
+++ b/x2paddle/decoder/onnx_decoder.py
@@ -50,7 +50,7 @@ class ONNXGraphNode(GraphNode):
 
     def get_input_index(self, input_name):
         """
-        get the index of input_name in layer.input
+        get the index of input_name in the layer.input
         -1 means input_name is not in the input
         """
         index = -1

--- a/x2paddle/op_mapper/onnx2paddle/opset_legacy.py
+++ b/x2paddle/op_mapper/onnx2paddle/opset_legacy.py
@@ -19,7 +19,7 @@ from functools import reduce
 import numpy as np
 import onnx
 import onnx.numpy_helper as numpy_helper
-from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE
+from onnx.helper import tensor_dtype_to_np_dtype
 import logging as _logging
 from collections import OrderedDict
 import math
@@ -1506,7 +1506,7 @@ class OpSet():
 
         dtype = node.get_attr('to')
         if not isinstance(dtype, np.dtype):
-            dtype = TENSOR_TYPE_TO_NP_TYPE[dtype]
+            dtype = tensor_dtype_to_np_dtype(dtype)
 
         output_dtype = val_output.dtype
         if output_dtype:


### PR DESCRIPTION
## PR Summary / 变更摘要

### English

This pull request refactors the ONNX type mapping logic in the X2Paddle project to use the `tensor_dtype_to_np_dtype` function. The update is necessary because `onnx.mapping` is no longer available in recent ONNX versions, causing runtime errors. By centralizing type conversion through `tensor_dtype_to_np_dtype`, code maintainability, consistency, and compatibility with new ONNX releases are improved.

#### Key Points
- Removed all usage of the deprecated `onnx.mapping` module.
- Replaced ONNX-to-NumPy dtype mapping with calls to `tensor_dtype_to_np_dtype`.
- Prevents errors related to missing `onnx.mapping` and ensures future compatibility.
- Improves code clarity and maintainability.

---

### 中文

本拉取请求将 X2Paddle 项目中的 ONNX 类型映射逻辑重构为使用 `tensor_dtype_to_np_dtype` 函数。由于新版本的 ONNX 已不再包含 `onnx.mapping`，原有代码会报错，因此此更改是必须的。通过统一使用 `tensor_dtype_to_np_dtype` 进行类型转换，提高了代码的可维护性、一致性，并确保与新版 ONNX 的兼容性。

#### 主要内容
- 移除了所有对过时的 `onnx.mapping` 模块的使用。
- 统一采用 `tensor_dtype_to_np_dtype` 进行 ONNX 到 NumPy 类型的映射。
- 避免因缺少 `onnx.mapping` 而导致的错误，并确保未来兼容性。
- 提升了代码的清晰度和可维护性。
