### PR TITLE
[Fix] aten_avg_pool1d 越界访问 avg_pool1d 不存在的 divisor_override

### DIFF
--- a/test_autoscan/torch/test_auto_scan_avg_pool1d.py
+++ b/test_autoscan/torch/test_auto_scan_avg_pool1d.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2022  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from auto_scan_test import OPConvertAutoScanTest, BaseNet
+from hypothesis import reproduce_failure
+import hypothesis.strategies as st
+import torch
+import numpy as np
+import unittest
+
+
+class Net(BaseNet):
+    """
+    simple Net
+    """
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = torch.nn.functional.avg_pool1d(
+            inputs,
+            kernel_size=self.config["kernel_size"],
+            stride=self.config["stride"],
+            padding=self.config["padding"],
+            ceil_mode=self.config["ceil_mode"],
+            count_include_pad=self.config["count_include_pad"])
+        return x
+
+
+class TestAvgPool1dConvert(OPConvertAutoScanTest):
+    """
+    Torch API: torch.nn.functional.avg_pool1d
+    """
+
+    def sample_convert_config(self, draw):
+        input_shape = draw(
+            st.lists(st.integers(min_value=16, max_value=32),
+                     min_size=3,
+                     max_size=3))
+
+        kernel_size = draw(st.integers(min_value=1, max_value=5))
+        stride = draw(st.integers(min_value=1, max_value=5))
+        padding = draw(st.integers(min_value=0, max_value=kernel_size // 2))
+        ceil_mode = draw(st.booleans())
+        count_include_pad = draw(st.booleans())
+
+        config = {
+            "op_names": ["avg_pool1d"],
+            "test_data_shapes": [input_shape],
+            "test_data_types": [['float32']],
+            "inputs_shape": [[-1, input_shape[1], -1]],
+            "kernel_size": kernel_size,
+            "stride": stride,
+            "padding": padding,
+            "ceil_mode": ceil_mode,
+            "count_include_pad": count_include_pad,
+            "delta": 1e-4,
+            "rtol": 1e-4,
+        }
+
+        models = Net(config)
+
+        return (config, models)
+
+    def test(self):
+        self.run_and_statis(max_examples=30)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/x2paddle/op_mapper/pytorch2paddle/aten.py
+++ b/x2paddle/op_mapper/pytorch2paddle/aten.py
@@ -641,9 +641,9 @@ def aten_avg_pool3d(mapper, graph, node):
 
 
 def aten_avg_pool1d(mapper, graph, node):
-    """ 构造最大池化的PaddleLayer。
+    """ 构造平均池化的PaddleLayer。
     TorchScript示例:
-        %branch_pool.2 : Tensor = aten::avg_pool1d(%x.43, %538, %539, %540, %273, %272, %271)
+        %branch_pool.2 : Tensor = aten::avg_pool1d(%x.43, %538, %539, %540, %273, %272)
         参数含义:
         %branch_pool.2 (Tensor): 输出，池化后的结果。
         %x.43 (Tensor): 需要池化的Tensor。
@@ -652,10 +652,9 @@ def aten_avg_pool1d(mapper, graph, node):
         %540 (list): 填充大小。
         %273 (bool): 是否用ceil函数计算输出高度和宽度。
         %272 (bool): 是否在平均池化模式不忽略填充值，False为忽略。
-        %271 (int): 如果指定，它将用作除数，否则将使用池化区域的大小。
     """
     scope_name = mapper.normalize_scope_name(node)
-    op_name = name_generator("pool2d", mapper.nn_name2id)
+    op_name = name_generator("pool1d", mapper.nn_name2id)
     output_name = mapper._get_outputs_name(node)[0]
     layer_outputs = [op_name, output_name]
     layer_inputs = {}
@@ -679,15 +678,6 @@ def aten_avg_pool1d(mapper, graph, node):
     layer_attrs["ceil_mode"] = mapper.attrs[inputs_name[4]]
     # 处理输入5，即%272
     layer_attrs["exclusive"] = not mapper.attrs[inputs_name[5]]
-    # 处理输入6，即%271
-    graph.add_layer("prim.assert",
-                    inputs={},
-                    outputs=[inputs_name[6] + "_assert"],
-                    scope_name=scope_name if scope_name == "" else scope_name +
-                    "_assert",
-                    type="eq",
-                    key=mapper.attrs[inputs_name[6]],
-                    value=None)
 
     graph.add_layer(kernel="paddle.nn.AvgPool1D",
                     inputs=layer_inputs,


### PR DESCRIPTION
Fixes #1122

## 问题
aten::avg_pool1d 仅 6 个输入 (input, kernel_size, stride, padding, ceil_mode, count_include_pad)，无 divisor_override。aten_avg_pool1d 由 aten_avg_pool2d 复制而来，遗留了对第 7 个输入 inputs_name[6] 的 prim.assert，_get_inputs_name 返回长度为 6，导致任何 AvgPool1d 转换必现 IndexError (aten.py:685)。

## 改动
- aten.py：删除处理 divisor_override 的 prim.assert 块；修正 docstring（最大→平均、去掉第 7 参数）与 name_generator 命名（pool2d→pool1d）。余下 attr（kernel_size/stride/padding/ceil_mode/exclusive）均为 paddle.nn.AvgPool1D 合法参数。
- 新增 test_autoscan/torch/test_auto_scan_avg_pool1d.py。此前 test_autoscan/torch 下无任何 pooling 测试，这也是该问题长期未被发现的原因。

## 验证
- 修复前：含 AvgPool1d 的模型转换必现 IndexError；修复后转换正常。
- 映射语义（exclusive = not count_include_pad、padding、ceil_mode）在多组配置下 paddle.nn.AvgPool1D 与 torch.avg_pool1d 输出逐值一致。
- 端到端由新增的 autoscan 用例覆盖。
